### PR TITLE
Chefdk update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.0.0
 script:
   - rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 
 # 0.2.0.dev (unreleased)
-
- * rename plugin to "vagrant-toplevel-cookbooks"
+   
+ * several **breaking changes**:
+   * rename plugin to "vagrant-toplevel-cookbooks"
+   * update to berkshelf 3 for [ChefDK](http://www.getchef.com/downloads/chef-dk) (berkshelf 2 is no longer supported)
+   * remove berkshelf gem dependency (`berks` must be on the `$PATH`)
+ * update development dependencies to latest vagrant 1.6 and adapt Vagrantfile samples
 
 # 0.1.4 (Oct 5, 2013)
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", "1.3.4",
+  gem "vagrant", "1.6.3",
     :git => "https://github.com/mitchellh/vagrant.git",
-    :ref => "v1.3.4"
-  gem "vagrant-omnibus", "1.1.1"
-  gem "vagrant-cachier", "0.3.3"
+    :ref => "v1.6.3"
+  gem "vagrant-omnibus", "1.4.1"
+  gem "vagrant-cachier", "0.7.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
   gem "vagrant", "1.6.3",
     git: "https://github.com/mitchellh/vagrant.git",
     ref: "v1.6.3"
+  gem "berkshelf", "3.1.3"
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,12 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", "1.6.3",
-    :git => "https://github.com/mitchellh/vagrant.git",
-    :ref => "v1.6.3"
+    git: "https://github.com/mitchellh/vagrant.git",
+    ref: "v1.6.3"
+end
+
+group :plugins do
+  gem "vagrant-toplevel-cookbooks", path: "."
   gem "vagrant-omnibus", "1.4.1"
   gem "vagrant-cachier", "0.7.2"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   #
   config.vm.define :my_app do |my_app_config|
     # app cookbook to deploy
-    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook-cookbook"
+    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
 
     my_app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,11 +8,11 @@ Vagrant.require_plugin "vagrant-cachier"
 
 Vagrant.configure("2") do |config|
 
-  config.omnibus.chef_version = "11.6.0"
+  config.omnibus.chef_version = "11.12.8"
   config.cache.auto_detect = true
 
-  config.vm.box = "opscode_ubuntu-12.04_provisionerless"
-  config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
+  config.vm.box = "opscode_ubuntu-14.04"
+  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
 
   #
   # configure vm to be deployed with toplevel cookbook

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
 
   config.omnibus.chef_version = "11.12.8"
-  config.cache.auto_detect = true
+  config.cache.scope = :box
 
   config.vm.box = "opscode_ubuntu-14.04"
   config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# require plugin for testing via bundler
-Vagrant.require_plugin "vagrant-toplevel-cookbooks"
-Vagrant.require_plugin "vagrant-omnibus"
-Vagrant.require_plugin "vagrant-cachier"
-
 Vagrant.configure("2") do |config|
 
   config.omnibus.chef_version = "11.12.8"
@@ -19,7 +14,8 @@ Vagrant.configure("2") do |config|
   #
   config.vm.define :my_app do |my_app_config|
     # app cookbook to deploy
-    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook"
+    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-application-cookbook"
+    my_app_config.toplevel_cookbook.ref = "chefdk-update"
 
     my_app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,16 +6,15 @@ Vagrant.configure("2") do |config|
   config.omnibus.chef_version = "11.12.8"
   config.cache.scope = :box
 
-  config.vm.box = "opscode_ubuntu-13.04"
-  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.04_chef-provisionerless.box"
+  config.vm.box = "opscode_ubuntu-12.04"
+  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box"
 
   #
   # configure vm to be deployed with toplevel cookbook
   #
   config.vm.define :my_app do |my_app_config|
     # app cookbook to deploy
-    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-application-cookbook"
-    my_app_config.toplevel_cookbook.ref = "chefdk-update"
+    my_app_config.toplevel_cookbook.url = "https://github.com/tknerr/sample-toplevel-cookbook-cookbook"
 
     my_app_config.vm.provision :chef_solo do |chef|
       chef.add_recipe "sample-app"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,8 @@ Vagrant.configure("2") do |config|
   config.omnibus.chef_version = "11.12.8"
   config.cache.scope = :box
 
-  config.vm.box = "opscode_ubuntu-14.04"
-  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
+  config.vm.box = "opscode_ubuntu-13.04"
+  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-13.04_chef-provisionerless.box"
 
   #
   # configure vm to be deployed with toplevel cookbook

--- a/lib/vagrant-toplevel-cookbooks/action/clone.rb
+++ b/lib/vagrant-toplevel-cookbooks/action/clone.rb
@@ -74,9 +74,8 @@ module VagrantPlugins
 
         def install_cookbooks
           Dir.chdir(cloned_repo_path) do
-            require 'berkshelf'
-            berksfile = Berkshelf::Berksfile.from_file('Berksfile')
-            berksfile.install(path: cookbook_install_path)
+            FileUtils.rm_rf cookbook_install_path
+            system "berks vendor #{cookbook_install_path}"
           end
         end
 

--- a/lib/vagrant-toplevel-cookbooks/plugin.rb
+++ b/lib/vagrant-toplevel-cookbooks/plugin.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
         Config
       end
 
+      require_relative "action"
       clone_action_hook = lambda do |hook|
         hook.before Vagrant::Action::Builtin::ConfigValidate, VagrantPlugins::TopLevelCookbooks::Action::Clone
       end

--- a/vagrant-toplevel-cookbooks.gemspec
+++ b/vagrant-toplevel-cookbooks.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-toplevel-cookbooks"
 
-  s.add_dependency "berkshelf", "~> 2.0.10"
+  s.add_dependency "berkshelf", "~> 3.1"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"

--- a/vagrant-toplevel-cookbooks.gemspec
+++ b/vagrant-toplevel-cookbooks.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-toplevel-cookbooks"
 
-  s.add_dependency "berkshelf", "~> 3.1"
-
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"
   s.add_development_dependency "rspec-expectations", "~> 2.12.1"


### PR DESCRIPTION
Update the plugin to work with ChefDK / Berks 3 and latest Vagrant version. Also rename to "vagrant-toplevel-cookbooks" (see README)

Summary of changes: 
- several **breaking changes**:
  - rename plugin to "vagrant-toplevel-cookbooks"
  - update to berkshelf 3 for [ChefDK](http://www.getchef.com/downloads/chef-dk) (berkshelf 2 is no longer supported)
  - remove berkshelf gem dependency (`berks` must be on the `$PATH`)
  - update development dependencies to latest vagrant 1.6 and adapt Vagrantfile samples
